### PR TITLE
support for jitpack

### DIFF
--- a/.github/workflows/build-citygml4j.yml
+++ b/.github/workflows/build-citygml4j.yml
@@ -1,0 +1,31 @@
+name: Build citygml4j
+
+on:
+  push:
+    branches:
+      - citygml3-devel
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-latest", "windows-latest"]
+        java: ["11"]
+        distribution: ["temurin"]
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
+      - name: Set up Java
+        uses: actions/setup-java@v2.5.0
+        with:
+          distribution: ${{ matrix.distribution }}
+          java-version: ${{ matrix.java }}
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -143,8 +143,10 @@ publishing {
     }
 }
 
-signing {
-    sign publishing.publications.mavenJava
+if (!project.hasProperty("skip.signing")) {
+    signing {
+        sign publishing.publications.mavenJava
+    }
 }
 
 nexusPublishing {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,6 @@
+jdk:
+  - openjdk11
+before_install:
+   - chmod +x ./gradlew
+install:
+   - ./gradlew build publishToMavenLocal -Pskip.signing


### PR DESCRIPTION
[Jitpack.io](https://jitpack.io) is a package repository for JVM building artifacts on demand.
This PR adds the config file, so that other projects can consume citygml4j jars via jitpack.