### PR TITLE
Fixed unmarshalling of generic date attribute

### DIFF
--- a/src/main/java/org/citygml4j/builder/jaxb/unmarshal/citygml/generics/Generics100Unmarshaller.java
+++ b/src/main/java/org/citygml4j/builder/jaxb/unmarshal/citygml/generics/Generics100Unmarshaller.java
@@ -41,6 +41,7 @@ import org.citygml4j.util.mapper.CheckedTypeMapper;
 import org.citygml4j.xml.io.reader.MissingADESchemaException;
 
 import javax.xml.bind.JAXBElement;
+import java.time.LocalDate;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class Generics100Unmarshaller {
@@ -162,8 +163,9 @@ public class Generics100Unmarshaller {
 	public void unmarshalDateAttribute(DateAttributeType src, DateAttribute dest) {
 		unmarshalAbstractGenericAttribute(src, dest);
 
-		if (src.isSetValue())
-			dest.setValue(src.getValue().toGregorianCalendar().toZonedDateTime().toLocalDate());
+		if (src.isSetValue()) {
+			dest.setValue(LocalDate.of(src.getValue().getYear(), src.getValue().getMonth(), src.getValue().getDay()));
+		}
 	}
 
 	public DateAttribute unmarshalDateAttribute(DateAttributeType src) {

--- a/src/main/java/org/citygml4j/builder/jaxb/unmarshal/citygml/generics/Generics200Unmarshaller.java
+++ b/src/main/java/org/citygml4j/builder/jaxb/unmarshal/citygml/generics/Generics200Unmarshaller.java
@@ -46,6 +46,7 @@ import org.citygml4j.util.mapper.CheckedTypeMapper;
 import org.citygml4j.xml.io.reader.MissingADESchemaException;
 
 import javax.xml.bind.JAXBElement;
+import java.time.LocalDate;
 import java.util.concurrent.locks.ReentrantLock;
 
 public class Generics200Unmarshaller {
@@ -170,7 +171,7 @@ public class Generics200Unmarshaller {
 		unmarshalAbstractGenericAttribute(src, dest);
 
 		if (src.isSetValue())
-			dest.setValue(src.getValue().toGregorianCalendar().toZonedDateTime().toLocalDate());
+			dest.setValue(LocalDate.of(src.getValue().getYear(), src.getValue().getMonth(), src.getValue().getDay()));
 	}
 
 	public DateAttribute unmarshalDateAttribute(DateAttributeType src) {


### PR DESCRIPTION
This PR fixes the issue, where the date `0001-01-01` is wrongly unmarshalled to `0000-12-31`. 
https://github.com/3dcitydb/importer-exporter/issues/280

